### PR TITLE
Get nonES6 to work the ES6 way 

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -6,6 +6,7 @@ import { copy } from 'esbuild-plugin-copy';
 import fs from 'fs-extra';
 import path from 'path';
 import  { getBuildNumber } from './utils/index.js';
+import morgan from 'morgan';
 
 // Load environment variables from .env file
 dotenv.config();
@@ -43,7 +44,16 @@ const build = async () => {
   try {
     // List of additional external dependencies
     const additionalExternals = [
-      'express', 'nunjucks', 'dotenv', 'crypto', 'cookie-signature', 'cookie-parser', 'body-parser', 'express-session'
+      'express',
+      'nunjucks',
+      'dotenv',
+      'crypto',
+      'cookie-signature',
+      'cookie-parser',
+      'body-parser',
+      'express-session',
+      'morgan',
+      'compression'
     ];
 
     // Combine core Node.js modules with additional external dependencies

--- a/src/app.js
+++ b/src/app.js
@@ -1,15 +1,12 @@
 import express from 'express';
-import { createRequire } from 'module';
+import morgan from 'morgan';
+import compression from 'compression';
 import { csrfProtection , setupMiddlewares, setupConfig } from '../middleware';
 import session from 'express-session';
 import {nunjucksSetup, rateLimitSetUp, helmetSetup} from '../utils';
 import config from '../config';
 import indexRouter from '../routes/index';
 import livereload from 'connect-livereload';
-
-const require = createRequire(import.meta.url);
-const logger = require('morgan');
-const compression = require('compression');
 
 const app = express();
 
@@ -102,7 +99,7 @@ setupConfig(app);
 /**
  * Sets up request logging using Morgan for better debugging and analysis.
  */
-app.use(logger('dev'));
+app.use(morgan('dev'));
 
 /**
  * Registers the main router for the application.


### PR DESCRIPTION
### Morgan and compress can be used in es6 way
This pull request includes several changes to the `esbuild.js` and `src/app.js` files to improve the build process and application setup. The most important changes include adding new dependencies, updating the list of external dependencies, and refactoring the middleware setup.

### Improvements to build process:

* [`esbuild.js`](diffhunk://#diff-4b2ed47327851d566740a30ce5f60271c059ae67eff2006bc07bb7c4fcee8b50L46-R56): Added `morgan` and `compression` to the list of additional external dependencies.

### Middleware setup refactoring:

* [`src/app.js`](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6L2-L13): Replaced the `createRequire` import with direct imports of `morgan` and `compression`.
* [`src/app.js`](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6L105-R102): Updated the middleware setup to use the imported `morgan` instead of the `require` method.

### Dependency additions:

* [`esbuild.js`](diffhunk://#diff-4b2ed47327851d566740a30ce5f60271c059ae67eff2006bc07bb7c4fcee8b50R9): Added `morgan` as a new import for request logging.
* [`src/app.js`](diffhunk://#diff-c72a907ac323cd2f334ed0e2bd07d15ab62581c4753660c8a0d1c681b30be4b6L2-L13): Added `morgan` and `compression` as new imports for logging and compression middleware.