### PR TITLE
Resolve high vulnerability in the npm installation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1084,9 +1084,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "node": "22.13.1"
   },
   "dependencies": {
-    "axios": "^1.7.9",
+    "axios": "^1.8.4",
     "body-parser": "^1.20.3",
     "chalk": "^5.4.1",
     "compression": "^1.7.4",


### PR DESCRIPTION

## What changed and Why?

When you run `npm install` it warns of a high vulnerability. Details of this vulnerability can be found here: https://security.snyk.io/vuln/SNYK-JS-AXIOS-9292519


This PR resolves this by committing the result of the `npm audit fix`, which bumps axios up to 1.8.4

## Checklist

Before you ask people to review this PR:

- [X] **Tests and linting** are passing.  
- [X] **Branch is up to date** with `main` (no merge conflicts).  
- [X] **No unnecessary whitespace changes** (avoid unnecessary diffs).  
- [X] **PR description clearly explains** what changed and why, with a JIRA ticket/Trello link.  
- [X] **Diff has been checked** for any unexpected changes.  
- [X] **Commit messages are clear** and explain what will change, if individual commit, needs to be revisited retroactively.