### PR TITLE
feat: Improved nodemon watch command to include projects JS file chan…

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clean": "rimraf public",
     "build": "npm run clean && node esbuild.js",
     "lint": "npx eslint . --ignore-pattern \"node_modules/*\" --ignore-pattern \"public/*\" --fix",
-    "dev": "nodemon --watch src --watch routes --watch views --watch *.js --ext js,scss --ignore public/ --ignore node_modules --exec 'node start-server.js'"
+    "dev": "nodemon --watch . --ext js,json,scss,njk --ignore node_modules --ignore public/ --delay 500ms --exec 'node start-server.js'"
   },
   "engines": {
     "node": "22.13.1"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clean": "rimraf public",
     "build": "npm run clean && node esbuild.js",
     "lint": "npx eslint . --ignore-pattern \"node_modules/*\" --ignore-pattern \"public/*\" --fix",
-    "dev": "nodemon --watch src --ext js,scss --exec 'node start-server.js'"
+    "dev": "nodemon --watch src --watch routes --watch views --watch *.js --ext js,scss --ignore public/ --ignore node_modules --exec 'node start-server.js'"
   },
   "engines": {
     "node": "22.13.1"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clean": "rimraf public",
     "build": "npm run clean && node esbuild.js",
     "lint": "npx eslint . --ignore-pattern \"node_modules/*\" --ignore-pattern \"public/*\" --fix",
-    "dev": "nodemon --watch . --ext js,json,scss,njk --ignore node_modules --ignore public/ --delay 500ms --exec 'node start-server.js'"
+    "dev": "nodemon --watch . --ext js,json,scss --ignore node_modules --ignore public/ --delay 500ms --exec 'node start-server.js'"
   },
   "engines": {
     "node": "22.13.1"


### PR DESCRIPTION
## What changed and Why?

Reports of live reload not working for projects JS files such as route and app. This is because the nodemon was not set to watch the project's JS files changes.

I have added/removed/altered:

- [ ] Updated `npm run dev` command
- [ ] Added ignore for public directory

I am doing this because:

Development is made harder but having to re-run build commands every time you change something in the project.

-->

## Guidance to review (optional)

Check command and unsure nothing is missed and could course problems.

## Checklist

Before you ask people to review this PR:

- [ ] **Tests and linting** are passing.  
- [ ] **Branch is up to date** with `main` (no merge conflicts).  
- [ ] **No unnecessary whitespace changes** (avoid unnecessary diffs).  
- [ ] **PR description clearly explains** what changed and why, with a JIRA ticket/Trello link.  
- [ ] **Diff has been checked** for any unexpected changes.  
- [ ] **Commit messages are clear** and explain what will change, if individual commit, needs to be revisited retroactively.